### PR TITLE
Updated Proton branding

### DIFF
--- a/docs/getting-started/one-click-unsubscribe.md
+++ b/docs/getting-started/one-click-unsubscribe.md
@@ -1,6 +1,6 @@
 One-click unsubscribe (or [RFC8058](https://datatracker.ietf.org/doc/html/rfc8058)) is provided by some email clients that allow you to quickly unsubscribe from a sender.
 
-Example from ProtonMail:
+Example from Proton Mail:
 
 ![](./one-click-unsubscribe-pm.png)
 

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -41,8 +41,8 @@ This video shows how to add `simplelogin.co` and `simplelogin.io` as safe sender
 
 [![How to set up filter in Hotmail](https://img.youtube.com/vi/Qk2TZA-ORx0/0.jpg)](https://www.youtube.com/watch?v=Qk2TZA-ORx0)
 
-### Create a ProtonMail filter
+### Create a Proton Mail filter
 
-The below video shows how to create a rule in ProtonMail to mark all emails that end with `@simplelogin.co` or `@simplelogin.io` as safe.
+The below video shows how to create a rule in Proton Mail to mark all emails that end with `@simplelogin.co` or `@simplelogin.io` as safe.
 
-[![How to set up filter in ProtonMail](https://img.youtube.com/vi/Ek28fFv8R3M/0.jpg)](https://www.youtube.com/watch?v=Ek28fFv8R3M)
+[![How to set up filter in Proton Mail](https://img.youtube.com/vi/Ek28fFv8R3M/0.jpg)](https://www.youtube.com/watch?v=Ek28fFv8R3M)

--- a/docs/mailbox/add-mailbox.md
+++ b/docs/mailbox/add-mailbox.md
@@ -1,4 +1,4 @@
-*Mailbox* is where emails sent to an alias are forwarded to. It's your usual mailbox, e.g. Gmail, Outlook, ProtonMail, etc.
+*Mailbox* is where emails sent to an alias are forwarded to. It's your usual mailbox, e.g. Gmail, Outlook, Proton Mail, etc.
 
 When you sign up for a SimpleLogin account, the email address you provided is used to create a default mailbox.
 


### PR DESCRIPTION
Changed "ProtonMail" to "Proton Mail" in all files

To Do:
- [x] Update the video on [this page](https://simplelogin.io/help/#protonmail) showing old Proton Mail UI

Note that updating the video is also a task in this [pull request in the website repo to update Proton branding](https://github.com/simple-login/website/pull/34).